### PR TITLE
Show the full cover image on post pages

### DIFF
--- a/styles/index.css
+++ b/styles/index.css
@@ -188,16 +188,19 @@ img {
 .featured:hover {
   opacity: 0.94;
 }
+/* Covers are content, not decoration — show all of the image, never crop it. */
 .cover {
   border-radius: 4px;
   overflow: hidden;
-  background: var(--rule-2);
-  aspect-ratio: 16 / 7;
+  display: flex;
+  justify-content: center;
 }
 .cover img {
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
+  width: auto;
+  height: auto;
+  max-width: 100%;
+  max-height: 460px;
+  object-fit: contain;
   display: block;
 }
 .meta-row {
@@ -403,20 +406,6 @@ img {
 }
 .post-cover {
   margin: 38px 0 48px;
-}
-/* On a post the cover is content, so show all of it — no 16/7 crop. */
-.post-cover .cover {
-  aspect-ratio: auto;
-  display: flex;
-  justify-content: center;
-  background: none;
-}
-.post-cover .cover img {
-  width: auto;
-  height: auto;
-  max-width: 100%;
-  max-height: 460px;
-  object-fit: contain;
 }
 .credit {
   font-family: var(--mono);

--- a/styles/index.css
+++ b/styles/index.css
@@ -404,6 +404,20 @@ img {
 .post-cover {
   margin: 38px 0 48px;
 }
+/* On a post the cover is content, so show all of it — no 16/7 crop. */
+.post-cover .cover {
+  aspect-ratio: auto;
+  display: flex;
+  justify-content: center;
+  background: none;
+}
+.post-cover .cover img {
+  width: auto;
+  height: auto;
+  max-width: 100%;
+  max-height: 460px;
+  object-fit: contain;
+}
 .credit {
   font-family: var(--mono);
   font-size: 11px;


### PR DESCRIPTION
Cover images were cropped to 16/7 with `object-fit: cover`. On [standups-are-not-cool](https://blog.caulagi.com/posts/standups-are-not-cool) that cut the outer two panels off a three-panel comic strip (the source gif is 700×218).

Covers now render at their natural aspect ratio everywhere — both the post page and the home page's featured card — capped at 460px tall and centred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)