### PR TITLE
Use tidier markdown without changing content

### DIFF
--- a/_posts/complementing-python-with-rust.mdx
+++ b/_posts/complementing-python-with-rust.mdx
@@ -264,7 +264,13 @@ and Clone. This is exactly same in a Python dictionary, where the keys have be
 hashable. But in the case of Rust, this is checked at compile type and doesn’t
 need unit-tests for this behaviour to hold.
 
-![Time taken in Rust and Python (lower is better)](https://cdn-images-1.medium.com/max/2000/1*NkDfVEodY6JRrst2XOLv4Q.png)_Time taken in Rust and Python (lower is better)_
+```shell
+$ python benchmark.py
+Time in rust: 2.5468742847442627
+Time in python: 3.2502663135528564
+```
+
+<Caption>Time taken in Rust and Python (lower is better).</Caption>
 
 As for the difference in performance, I used the same file that was used in the original article. Make 3/4 copies of [this file](http://norvig.com/big.txt) and put it in ‘data’ directory (the file names don’t matter).
 

--- a/_posts/complementing-python-with-rust.mdx
+++ b/_posts/complementing-python-with-rust.mdx
@@ -272,13 +272,18 @@ Time in python: 3.2502663135528564
 
 <Caption>Time taken in Rust and Python (lower is better).</Caption>
 
-As for the difference in performance, I used the same file that was used in the original article. Make 3/4 copies of [this file](http://norvig.com/big.txt) and put it in ‘data’ directory (the file names don’t matter).
+As for the difference in performance, I used the same file that was used in the original article.
+Make 3/4 copies of [this file](http://norvig.com/big.txt) and put it in ‘data’ directory (the file names don’t matter).
 
-My take aways from this exercise are — types in Rust are awesome and it is relatively easy to move code from Python to Rust when performance matters.
+My take aways from this exercise are — types in Rust are awesome and it is relatively easy
+to move code from Python to Rust when performance matters.
 
 Something I didn’t explore was to check if the benefits will be much higher for concurrent code.
 
-There are a few talks that I borrowed ideas from — [here](https://www.youtube.com/watch?v=-ylbuEzkG4M), [here](https://blog.sentry.io/2016/10/19/fixing-python-performance-with-rust.html) and [here](https://www.youtube.com/watch?v=3CwJ0MH-4MA). The first talk takes a different approach and uses [rust-cpython](https://github.com/dgrunwald/rust-cpython) for binding Python and Rust.
+There are a few talks that I borrowed ideas from — [here](https://www.youtube.com/watch?v=-ylbuEzkG4M),
+[here](https://blog.sentry.io/2016/10/19/fixing-python-performance-with-rust.html) and
+[here](https://www.youtube.com/watch?v=3CwJ0MH-4MA). The first talk takes a different approach and
+uses [rust-cpython](https://github.com/dgrunwald/rust-cpython) for binding Python and Rust.
 
 You can also watch a recording of the video, but if you have already read so far, there is nothing new in the video. I start at 3 mins.
 

--- a/_posts/first-look-at-golang.mdx
+++ b/_posts/first-look-at-golang.mdx
@@ -89,7 +89,7 @@ func main() {
 }
 ```
 
-### Types
+## Types
 
 ![](https://user-images.githubusercontent.com/222507/109426660-11572300-79ef-11eb-8165-65899ed34d05.png)
 
@@ -103,18 +103,28 @@ func serveFile(w ResponseWriter,
                redirect bool)
 ```
 
-### Stdlib
+## Stdlib
 
 <Quotation
   author="James Robertson about Smalltalk"
   quotation="Talk small and carry a big class library"
 />
 
-Go is frequently said to be a modern language. This is evident in the standard libraries that come with the language. compress, crypt, html, etc are all libraries any program today would invariably use. In fact, you will notice that the static file server earlier is really tiny. It is due to the fact that stdlib has a complete implementation of a HTTP server with parts that can be easily customized.
+Go is frequently said to be a modern language. This is evident in the standard libraries
+that come with the language. compress, crypt, html, etc are all libraries any program
+today would invariably use. In fact, you will notice that the static file server earlier
+is really tiny. It is due to the fact that stdlib has a complete implementation of a
+HTTP server with parts that can be easily customized.
 
-### Concurrency
+## Concurrency
 
-This was probably the single biggest reason to try Go. To write a concurrent program. And while there are a few awesome videos describing the constructs, there are not sufficient real-time examples on the web to make this easy. Furthermore, it is not easy breaking a mostly sequential program into concurrent pieces in Go. Consider the problem of getting some data from a database in a request-response cyle in a web application. This would be some example Nodejs (find a user asynchronously from the database. If that succeeds, return the user. Else return the error) -
+This was probably the single biggest reason to try Go. To write a concurrent program.
+And while there are a few awesome videos describing the constructs, there are not sufficient
+real-time examples on the web to make this easy. Furthermore, it is not easy breaking a
+mostly sequential program into concurrent pieces in Go. Consider the problem of getting
+some data from a database in a request-response cyle in a web application. This would be
+some example Nodejs (find a user asynchronously from the database. If that succeeds,
+return the user. Else return the error) -
 
 ```javascript
 User.findOne({ email: email }, function (err, user) {
@@ -131,12 +141,17 @@ User.findOne({ email: email }, function (err, user) {
 
 It is not clear how to break this into idiomatic Go code. Perhaps I need to spend more time with Go.
 
-### REPL
+## REPL
 
-As far as I can tell, there is no REPL for GO. This is something I missed terribly. Especially when you are learning a new language and want to try little snippets. No, I don’t want to use [play](http://play.golang.org/). I am far too used to the terminal.
+As far as I can tell, there is no REPL for GO. This is something I missed terribly.
+Especially when you are learning a new language and want to try little snippets.
+No, I don’t want to use [play](http://play.golang.org/). I am far too used to the terminal.
 
-There are a couple of other minor points. Having programmed in an interpreted language mostly, it was hard to switch over to the compiled mindset. In particular, the compile and restart server was pretty annoying. The other point is that it is not possible to change/add code to stdlib. I tend to add log lines quite a lot initially to understand an idea/concept. But this was ruled out for Go.
+There are a couple of other minor points. Having programmed in an interpreted language
+mostly, it was hard to switch over to the compiled mindset. In particular, the compile
+and restart server was pretty annoying. The other point is that it is not possible
+to change/add code to stdlib. I tend to add log lines quite a lot initially to understand
+an idea/concept. But this was ruled out for Go.
 
-All in all, it was an interesting weekend. But it wasn’t love at first sight. :|
-
-Don’t forget that these are my impressions after using Go for only 2 days. Also, these are my personal opinions. Feel free to disagree/discuss on [twitter](https://twitter.com/caulagi).
+All in all, it was an interesting weekend. But it wasn’t love at first sight. 😏
+Don’t forget that these are my impressions after using Go for only 2 days.

--- a/_posts/look-ma-kubernetes-objects.mdx
+++ b/_posts/look-ma-kubernetes-objects.mdx
@@ -19,19 +19,42 @@ In Structure and Interpretation of Computer Program, Abelson, Sussman, and Sussm
 
 These are my favorite questions to ask when looking at and trying to understand systems as well.
 
-In my previous role, I was working as a backend engineer and spent a few months making sure our rest-based microservices worked in Kubernetes. I made sure the applications worked well in containers, fixed logging and error reporting and health endpoints. My only motivation for all these changes was to be able to run these applications on Kubernetes. In hind sight, I had the correct goal but the wrong motivation. What I wanted to **achieve** was **operational simplicity**. I wanted to achieve a state where the applications will use resources optimally (small containers tightly packed together on nodes), scale up if traffic grows, heal automatically on errors, etc. I wanted to achieve this declaratively, so I can focus on the what (scale up if response times is more than 500ms) and not worry about the how. I wanted these guarantees constantly applied and the differences fixed.
+In my previous role, I was working as a backend engineer and spent a few months making sure our
+rest-based microservices worked in Kubernetes. I made sure the applications worked well in
+containers, fixed logging and error reporting and health endpoints. My only motivation for
+all these changes was to be able to run these applications on Kubernetes. In hind sight, I
+had the correct goal but the wrong motivation. What I wanted to **achieve** was
+**operational simplicity**. I wanted to achieve a state where the applications will use
+resources optimally (small containers tightly packed together on nodes), scale up if traffic
+grows, heal automatically on errors, etc. I wanted to achieve this declaratively, so I can
+focus on the what (scale up if response times is more than 500ms) and not worry about the how.
+I wanted these guarantees constantly applied and the differences fixed.
 
-Today I work as a Site Reliability Engineer. The goal of our team is to provide a stable platform for the development teams. I work with a mix of infrastructure — some in Google cloud and some in our datacenters. So on a typical day, our team might be defining how the network should look, change firewall rules, add/modify DNS entries, create rules in loadbalancers, provision VMs/Kubernetes clusters/managed-services, etc. Of course, we can argue that infrastructure is special and we need tools like Terraform to solve the above problems. But if we go back to Kubernetes…
+Today I work as a Site Reliability Engineer. The goal of our team is to provide a stable
+platform for the development teams. I work with a mix of infrastructure — some in Google cloud
+and some in our datacenters. So on a typical day, our team might be defining how the network
+should look, change firewall rules, add/modify DNS entries, create rules in loadbalancers,
+provision VMs/Kubernetes clusters/managed-services, etc. Of course, we can argue that infrastructure
+is special and we need tools like Terraform to solve the above problems. But if we go back to Kubernetes…
 
-There is one fundamental abstraction in Kubernetes applied uniformly from how I think about it. That of a [Kubernetes Resource Model (KRM)](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/architecture/resource-management.md). When you represent something as a KRM, it means two things —
+There is one fundamental abstraction in Kubernetes applied uniformly from how I think about it.
+That of a [Kubernetes Resource Model (KRM)](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/architecture/resource-management.md).
+When you represent something as a KRM, it means two things —
 
 <Code>Declarative</Code> We focus on specifying the intent/what.
 
 <Code>Reconciliation loop</Code> There is a controller that will reconcile the
 intent with the observed state constantly.
 
-There are already projects like [config-connector](https://cloud.google.com/config-connector/docs/overview) and [crossplane](https://github.com/crossplane/crossplane) that allow us to manage infrastructure with this approach to varying degrees. In this design, there is no distinction between an infrastructure component and an application component. Everything is represented uniformly as a KRM (which means declarative and reconciliation) and the same tools are applied to manage infrastructure and applications. So perhaps a modern way to provision infrastructure is to provision a Kubernetes cluster which will provision your infrastructure and your Kubernetes clusters which will run applications.
+There are already projects like [config-connector](https://cloud.google.com/config-connector/docs/overview)
+and [crossplane](https://github.com/crossplane/crossplane) that allow us to manage infrastructure
+with this approach to varying degrees. In this design, there is no distinction between an infrastructure
+component and an application component. Everything is represented uniformly as a KRM (which means
+declarative and reconciliation) and the same tools are applied to manage infrastructure and
+applications. So perhaps a modern way to provision infrastructure is to provision a Kubernetes
+cluster which will provision your infrastructure and your Kubernetes clusters which will run applications.
 
-What I want to achieve is a platform that will fix itself when there are problems so I can have beers on an island. Occasionally the system can’t fix itself and I will write some more yaml’s.
+What I want to achieve is a platform that will fix itself when there are problems so I can have
+beers on an island. Occasionally the system can’t fix itself and I will write some more yaml’s.
 
 What do you think?

--- a/_posts/standups-are-not-cool.mdx
+++ b/_posts/standups-are-not-cool.mdx
@@ -9,10 +9,10 @@ ogImage:
 tags: ['process']
 ---
 
-**Update (7 Nov 2023)** I wrote this article before Covid and when it was common to work from
-the same location. _I don't believe these arguments are applicable for a remote setup._
-I believe we need more opportunities for facetime in a remote setup and standup's
-provide a simple way to achieve that.
+> **Update (7 Nov 2023)** I wrote this article before Covid and when it was common to work from
+> the same location. _I don't believe these arguments are applicable for a remote setup._
+> I believe we need more opportunities for facetime in a remote setup and standup's
+> provide a simple way to achieve that.
 
 No, I am not an agile coach who has helped many teams deliver great results.
 I am just a developer who has read a couple of books on agile and taken part

--- a/_posts/weapons-of-choice.mdx
+++ b/_posts/weapons-of-choice.mdx
@@ -11,7 +11,9 @@ tags: ['nodejs']
 
 <Caption>How hattira.com looked before being discontinued</Caption>
 
-### Some experiences building a Nodejs project
+> **Update [1 Mar 2021]:** I don't work on the project anymore and the domain belongs to somebody else.
+
+## Some experiences building a Nodejs project
 
 I still remember my first conversation with our architect when
 I joined Yahoo! I had just introduced myself. As soon as I
@@ -20,9 +22,6 @@ you have opinions about everything!” He definitely thought me as a
 bit of [Clouseau](http://en.wikipedia.org/wiki/Inspector_Clouseau).
 
 Last month, I worked on a Nodejs project in my freetime —
-
-(_Update [1 Mar 2021]:_ I don't work on the project anymore and the domain belongs
-to somebody else).
 
 <strike>[hattira](http://hattira.com/)</strike>
 It is a community driven listing of events in a city. The idea was to answer the


### PR DESCRIPTION
* Replace image in rust-vs-python post with code block
* h2 headings render better
* use line breaks to make it easier to read
* Use callout in old post to clarify project status
