### PR TITLE
Use the post excerpt as the page meta description

### DIFF
--- a/components/layout.tsx
+++ b/components/layout.tsx
@@ -4,12 +4,13 @@ import SiteFooter from './site-footer'
 
 type LayoutProps = {
   children: React.ReactNode
+  description?: string
 }
 
-const Layout: React.FC<LayoutProps> = ({ children }) => {
+const Layout: React.FC<LayoutProps> = ({ children, description }) => {
   return (
     <>
-      <Meta />
+      <Meta description={description} />
       <div className="page shell">
         <SiteHeader />
         <main>{children}</main>

--- a/components/meta.tsx
+++ b/components/meta.tsx
@@ -5,7 +5,11 @@ import {
   SITE_DESCRIPTION,
 } from '../lib/constants'
 
-const Meta: React.FC = () => {
+type MetaProps = {
+  description?: string
+}
+
+const Meta: React.FC<MetaProps> = ({ description = SITE_DESCRIPTION }) => {
   return (
     <Head>
       <link
@@ -42,7 +46,7 @@ const Meta: React.FC = () => {
         href="/feed.xml"
       />
       <meta name="viewport" content="width=device-width, initial-scale=1" />
-      <meta name="description" content={SITE_DESCRIPTION} />
+      <meta name="description" content={description} />
       <meta property="og:image" content={HOME_OG_IMAGE_URL} key="ogImage" />
     </Head>
   )

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,7 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
 import "./.next/types/routes.d.ts";
-import "./.next/types/root-params.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/pages/api-reference/config/typescript for more information.

--- a/pages/about.tsx
+++ b/pages/about.tsx
@@ -20,7 +20,7 @@ const facts = [
 const About: React.FC = () => {
   const title = `About ${AUTHOR_NAME}`
   return (
-    <Layout>
+    <Layout description={lede}>
       <Head>
         <title>{title}</title>
         <meta property="og:image" content={HOME_OG_IMAGE_URL} key="ogImage" />

--- a/pages/posts/[slug].tsx
+++ b/pages/posts/[slug].tsx
@@ -45,7 +45,7 @@ const Post: React.FC<PostProps> = ({ post, source }) => {
 
   const tags = post.tags ?? []
   return (
-    <Layout>
+    <Layout description={post.excerpt}>
       <Head>
         <title>{post.title + ' | Blog of ' + AUTHOR_NAME}</title>
         <meta property="og:image" content={post.ogImage.url} key="ogImage" />


### PR DESCRIPTION
Every page served the same hardcoded site description. Posts now use their excerpt and the about page uses its lede; the home page keeps the site description.