### PR TITLE
Add canonical tags, a sitemap, robots.txt, structured data and profile links

### DIFF
--- a/components/json-ld.tsx
+++ b/components/json-ld.tsx
@@ -1,0 +1,17 @@
+type JsonLdProps = {
+  data: Record<string, unknown>
+}
+
+// Rendered in the body rather than <Head> — crawlers accept JSON-LD anywhere,
+// and next/head is fussy about script children.
+const JsonLd: React.FC<JsonLdProps> = ({ data }) => (
+  <script
+    type="application/ld+json"
+    // Escaping `<` keeps a stray "</script>" in the data from closing the tag.
+    dangerouslySetInnerHTML={{
+      __html: JSON.stringify(data).replace(/</g, '\\u003c'),
+    }}
+  />
+)
+
+export default JsonLd

--- a/components/meta.tsx
+++ b/components/meta.tsx
@@ -1,8 +1,11 @@
 import Head from 'next/head'
+import { useRouter } from 'next/router'
+
 import {
   AUTHOR_NAME,
   HOME_OG_IMAGE_URL,
   SITE_DESCRIPTION,
+  SITE_URL,
 } from '../lib/constants'
 
 type MetaProps = {
@@ -10,8 +13,13 @@ type MetaProps = {
 }
 
 const Meta: React.FC<MetaProps> = ({ description = SITE_DESCRIPTION }) => {
+  const { asPath } = useRouter()
+  // Query strings and fragments are never part of the canonical URL.
+  const canonical = SITE_URL + asPath.split(/[?#]/)[0]
   return (
     <Head>
+      <link rel="canonical" href={canonical} />
+      <meta property="og:url" content={canonical} key="ogUrl" />
       <link
         rel="apple-touch-icon"
         sizes="180x180"

--- a/components/site-footer.tsx
+++ b/components/site-footer.tsx
@@ -1,4 +1,9 @@
-import { AUTHOR_NAME, GIT_REPO, MASTODON_URL } from '../lib/constants'
+import {
+  AUTHOR_NAME,
+  GIT_REPO,
+  LINKEDIN_URL,
+  MASTODON_URL,
+} from '../lib/constants'
 
 const SiteFooter: React.FC = () => {
   return (
@@ -10,6 +15,10 @@ const SiteFooter: React.FC = () => {
         <a href="/feed.xml">RSS</a> ·{' '}
         <a href={MASTODON_URL} rel="me noreferrer" target="_blank">
           Mastodon
+        </a>{' '}
+        ·{' '}
+        <a href={LINKEDIN_URL} rel="me noreferrer" target="_blank">
+          LinkedIn
         </a>{' '}
         ·{' '}
         <a href={GIT_REPO} target="_blank" rel="noreferrer">

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -5,6 +5,9 @@ export const SITE_URL = 'https://blog.caulagi.com'
 export const SITE_DESCRIPTION =
   'Notes on distributed systems, platform engineering and the tools in between.'
 export const MASTODON_URL = 'https://mastodon.social/@caulagi'
+export const GITHUB_URL = 'https://github.com/caulagi'
+// Profiles claimed as the same person in the /about JSON-LD.
+export const SAME_AS = [GITHUB_URL, MASTODON_URL]
 export const EMAIL = 'caulagi@gmail.com'
 export const HOME_OG_IMAGE_URL =
   'https://og-image.now.sh/Next.js%20Blog%20Starter%20Example.png?theme=light&md=1&fontSize=100px&images=https%3A%2F%2Fassets.vercel.com%2Fimage%2Fupload%2Ffront%2Fassets%2Fdesign%2Fnextjs-black-logo.svg'

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -6,8 +6,17 @@ export const SITE_DESCRIPTION =
   'Notes on distributed systems, platform engineering and the tools in between.'
 export const MASTODON_URL = 'https://mastodon.social/@caulagi'
 export const GITHUB_URL = 'https://github.com/caulagi'
+export const LINKEDIN_URL = 'https://www.linkedin.com/in/pradipcaulagi/'
+export const X_URL = 'https://x.com/caulagi'
+export const PERSONAL_SITE_URL = 'https://caulagi.com/'
 // Profiles claimed as the same person in the /about JSON-LD.
-export const SAME_AS = [GITHUB_URL, MASTODON_URL]
+export const SAME_AS = [
+  PERSONAL_SITE_URL,
+  GITHUB_URL,
+  MASTODON_URL,
+  LINKEDIN_URL,
+  X_URL,
+]
 export const EMAIL = 'caulagi@gmail.com'
 export const HOME_OG_IMAGE_URL =
   'https://og-image.now.sh/Next.js%20Blog%20Starter%20Example.png?theme=light&md=1&fontSize=100px&images=https%3A%2F%2Fassets.vercel.com%2Fimage%2Fupload%2Ffront%2Fassets%2Fdesign%2Fnextjs-black-logo.svg'

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,7 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
 import "./.next/types/routes.d.ts";
+import "./.next/types/root-params.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/pages/api-reference/config/typescript for more information.

--- a/pages/about.tsx
+++ b/pages/about.tsx
@@ -1,11 +1,14 @@
 import Head from 'next/head'
 
 import ContactCard from '../components/contact-card'
+import JsonLd from '../components/json-ld'
 import Layout from '../components/layout'
 import {
   AUTHOR_NAME,
   AUTHOR_PICTURE,
   HOME_OG_IMAGE_URL,
+  SAME_AS,
+  SITE_URL,
 } from '../lib/constants'
 
 const lede =
@@ -17,10 +20,30 @@ const facts = [
   { label: 'Off the clock', value: 'Chess · long walks' },
 ]
 
+const person = {
+  '@context': 'https://schema.org',
+  '@type': 'Person',
+  name: AUTHOR_NAME,
+  description: lede,
+  url: `${SITE_URL}/about`,
+  image: `${SITE_URL}${AUTHOR_PICTURE}`,
+  jobTitle: 'Platform engineer',
+  knowsAbout: [
+    'Distributed systems',
+    'Platform engineering',
+    'Python',
+    'Go',
+    'Rust',
+    'Kubernetes',
+  ],
+  sameAs: SAME_AS,
+}
+
 const About: React.FC = () => {
   const title = `About ${AUTHOR_NAME}`
   return (
     <Layout description={lede}>
+      <JsonLd data={person} />
       <Head>
         <title>{title}</title>
         <meta property="og:image" content={HOME_OG_IMAGE_URL} key="ogImage" />

--- a/pages/posts/[slug].tsx
+++ b/pages/posts/[slug].tsx
@@ -14,12 +14,13 @@ import { serialize } from 'next-mdx-remote/serialize'
 
 import ContactCard from '../../components/contact-card'
 import CoverImage from '../../components/cover-image'
+import JsonLd from '../../components/json-ld'
 import DateFormatter from '../../components/date-formatter'
 import Layout from '../../components/layout'
 import PostBody from '../../components/post-body'
 import { getPostBySlug, getAllPosts } from '../../lib/api'
 import codeTheme from '../../lib/code-theme'
-import { AUTHOR_NAME, AUTHOR_PICTURE } from '../../lib/constants'
+import { AUTHOR_NAME, AUTHOR_PICTURE, SITE_URL } from '../../lib/constants'
 import rehypeCodeCard from '../../lib/rehype-code-card'
 import PostType from '../../types/post'
 
@@ -44,8 +45,27 @@ const Post: React.FC<PostProps> = ({ post, source }) => {
   }
 
   const tags = post.tags ?? []
+  const url = `${SITE_URL}/posts/${post.slug}`
+  const blogPosting = {
+    '@context': 'https://schema.org',
+    '@type': 'BlogPosting',
+    headline: post.title,
+    description: post.excerpt,
+    datePublished: post.date,
+    image: post.coverImage.src,
+    url,
+    mainEntityOfPage: { '@type': 'WebPage', '@id': url },
+    author: {
+      '@type': 'Person',
+      name: AUTHOR_NAME,
+      url: `${SITE_URL}/about`,
+    },
+    ...(tags.length > 0 && { keywords: tags.join(', ') }),
+  }
+
   return (
     <Layout description={post.excerpt}>
+      <JsonLd data={blogPosting} />
       <Head>
         <title>{post.title + ' | Blog of ' + AUTHOR_NAME}</title>
         <meta property="og:image" content={post.ogImage.url} key="ogImage" />

--- a/pages/sitemap.xml.tsx
+++ b/pages/sitemap.xml.tsx
@@ -1,0 +1,51 @@
+import { GetServerSideProps } from 'next'
+
+import { getAllPosts } from '../lib/api'
+import { SITE_URL } from '../lib/constants'
+
+const buildSitemap = (): string => {
+  const posts = getAllPosts(['slug', 'date'])
+  const newest = posts[0]?.date
+
+  const urls = [
+    // Trailing slash to match the canonical the home page emits.
+    { loc: `${SITE_URL}/`, lastmod: newest },
+    { loc: `${SITE_URL}/about`, lastmod: undefined },
+    ...posts.map((post) => ({
+      loc: `${SITE_URL}/posts/${post.slug}`,
+      lastmod: post.date,
+    })),
+  ]
+
+  const entries = urls
+    .map(({ loc, lastmod }) => {
+      const date = lastmod
+        ? `\n    <lastmod>${new Date(lastmod).toISOString().slice(0, 10)}</lastmod>`
+        : ''
+      return `  <url>\n    <loc>${loc}</loc>${date}\n  </url>`
+    })
+    .join('\n')
+
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+${entries}
+</urlset>
+`
+}
+
+// The page itself never renders — getServerSideProps writes the XML directly.
+const Sitemap: React.FC = () => null
+
+export default Sitemap
+
+export const getServerSideProps: GetServerSideProps = async ({ res }) => {
+  res.setHeader('Content-Type', 'application/xml; charset=utf-8')
+  res.setHeader(
+    'Cache-Control',
+    'public, s-maxage=3600, stale-while-revalidate=86400',
+  )
+  res.write(buildSitemap())
+  res.end()
+
+  return { props: {} }
+}

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://blog.caulagi.com/sitemap.xml


### PR DESCRIPTION
Every page now emits a canonical URL and og:url. Adds /sitemap.xml and robots.txt, plus JSON-LD: BlogPosting on each post and Person on the about page. The about page structured data claims the personal site, GitHub, Mastodon, LinkedIn and X profiles, and LinkedIn is added to the footer.