### PR TITLE
Give posts a separate SEO title from the display heading

### DIFF
--- a/_posts/complementing-python-with-rust.mdx
+++ b/_posts/complementing-python-with-rust.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Complementing Python With Rust'
+seoTitle: 'Calling Rust from Python with cffi: a performance benchmark'
 excerpt: 'I show how we can offload performance critical parts of a Python codebase to use Rust. Rust is a fast systems language with performance close to C.'
 coverImage:
   src: 'https://cdn-images-1.medium.com/max/2560/1*C1P0N253ts3T6vfiNlr5Pw.jpeg'

--- a/_posts/first-look-at-golang.mdx
+++ b/_posts/first-look-at-golang.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'First look at golang'
+seoTitle: 'Writing a static file server in Go: first impressions'
 excerpt: 'I spent the weekend playing with Go. Specifically, I built a simple HTTP static file server. I have some first impressions.'
 coverImage:
   src: 'https://user-images.githubusercontent.com/222507/109426713-51b6a100-79ef-11eb-8a45-a528f9be945b.png'

--- a/_posts/look-ma-kubernetes-objects.mdx
+++ b/_posts/look-ma-kubernetes-objects.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Look ma, kubernetes objects'
+seoTitle: 'Provisioning infrastructure with the Kubernetes Resource Model'
 excerpt: 'I suggest that we should use kubernetes to provision infrastructure so that we can build a platform that fixes itself when there are problems and we can spend the idle time on an island.'
 coverImage:
   src: 'https://user-images.githubusercontent.com/222507/109411007-21dfad00-799f-11eb-8ac8-b89cd3f8c2c0.jpg'

--- a/_posts/nodejs-vs-django.mdx
+++ b/_posts/nodejs-vs-django.mdx
@@ -1,5 +1,6 @@
 ---
-title: 'Nodejs vs Django'
+title: 'Node.js vs Django'
+seoTitle: 'Node.js vs Django: how to choose a backend framework'
 excerpt: 'We have been using both Django and Nodejs at WWStay. We use Django for the customer dashboard and Nodejs for the web application that aggregates different hotel rates from various vendors. Based on my experiences, I have a checklist that I use to determine what framework to use.'
 coverImage:
   src: 'https://user-images.githubusercontent.com/222507/109427622-7ad93080-79f3-11eb-8411-519e3a696f6f.png'

--- a/_posts/python-concurrent-futures.mdx
+++ b/_posts/python-concurrent-futures.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Python: concurrent.futures'
+seoTitle: 'Python concurrent.futures: running downloads in parallel'
 excerpt: 'I had been wanting to try some new features of Python 3 for a while now. I recently found some free time and tried concurrent.futures. Concurrent.futures allows us to write code that runs in parallel in Python without resorting to creating threads or forking processes.'
 coverImage:
   src: 'https://user-images.githubusercontent.com/222507/109425295-e87f5f80-79e7-11eb-8cc8-2d73a5dd3982.png'

--- a/_posts/secret-sauce.mdx
+++ b/_posts/secret-sauce.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'The secret sauce'
+seoTitle: 'Error reporting, not logging, is the core of observability'
 excerpt: 'I argue that the most important component for observability in a microservices/distributed architecture is error reporting.'
 coverImage:
   src: 'https://user-images.githubusercontent.com/222507/148700710-cd6466ff-059b-4631-94be-bf19e7a70832.jpg'

--- a/_posts/standups-are-not-cool.mdx
+++ b/_posts/standups-are-not-cool.mdx
@@ -1,6 +1,7 @@
 ---
-title: "Standup's are not cool"
-excerpt: 'So I find it strange that we start with the principle of self-organizing teams and then conclude — standup’s at 9! How does open-source work if standup’s are how development should be done?'
+title: 'Standups are not cool'
+seoTitle: 'The case against daily standups for co-located teams'
+excerpt: 'So I find it strange that we start with the principle of self-organizing teams and then conclude — standups at 9! How does open-source work if standups are how development should be done?'
 coverImage:
   src: 'https://user-images.githubusercontent.com/222507/109423898-a6531f80-79e1-11eb-9cbc-d126ddb95268.gif'
 date: '2016-12-20T05:35:07.322Z'
@@ -11,15 +12,15 @@ tags: ['process']
 
 > **Update (7 Nov 2023)** I wrote this article before Covid and when it was common to work from
 > the same location. _I don't believe these arguments are applicable for a remote setup._
-> I believe we need more opportunities for facetime in a remote setup and standup's
+> I believe we need more opportunities for facetime in a remote setup and standups
 > provide a simple way to achieve that.
 
 No, I am not an agile coach who has helped many teams deliver great results.
 I am just a developer who has read a couple of books on agile and taken part
-in my share of standup’s. I am now at a stage where I don’t see the value
+in my share of standups. I am now at a stage where I don’t see the value
 they bring. Why do we need them anyway?
 
-The way I have practised standup’s is — each member of the team provides a
+The way I have practised standups is — each member of the team provides a
 brief update on what he worked on yesterday, what he will do today and if
 there are any blockers. I have also seen variations of this — there is a
 ball that is passed around and only the person with the ball talks.
@@ -31,7 +32,7 @@ to other members of the team about our progress (or the lack of it).
 
 Lets talk about communication. To me, communication means “shared understanding”.
 I often find that standup is a pretty bad medium to achieve this.
-Especially because standup’s discourage discussion and questions.
+Especially because standups discourage discussion and questions.
 I have a hard time imagining how we can have a shared understanding
 without a dialogue. At best, an update like — I added a ‘remember me’
 option on the login page — is information. For a shared understanding,
@@ -45,7 +46,7 @@ uses for updating each other? Is there no free flow of information within
 the team and across teams? Perhaps there are several layers of hierarchy
 that need to be updated? Maybe the team mates don’t talk to each other
 unless asked to? Or it is difficult to see the state of the project without
-talking to the team. In all these cases, standup’s suppresses the symptom
+talking to the team. In all these cases, standups suppresses the symptom
 without curing it.
 
 My last crib about this form of communication is the frequency. One day is either
@@ -56,15 +57,15 @@ more points in the next section.
 
 So that brings me to progress. But let me take a digression first and talk about a related idea — effort.
 
-Many times (during standup’s), we talk about effort and not progress.
+Many times (during standups), we talk about effort and not progress.
 Imagine a typical update like — I worked on updating the MySQL client library.
 This is effort. In a few rare cases, it is followed by — I hope to finish it
-tomorrow (50% done?). But if you think about it, the entire format of standup’s
+tomorrow (50% done?). But if you think about it, the entire format of standups
 is based on an assumption. It is based on the assumption that daily effort corresponds
 directly to progress. I wish this were true. But most often, it is not. In fact,
 this is the fundamental idea in Fred Brooks classic — the mythical man month — that
 effort doesn’t imply progress. So if daily effort doesn’t automatically mean progress,
-standup’s are a pretty bad medium for tracking progress.
+standups are a pretty bad medium for tracking progress.
 
 Which brings me to my next point. Progress, at least in software, and for me,
 is binary. Either you released a feature/bug-fix to production or you didn’t.
@@ -75,13 +76,13 @@ that would require the same effort as the initial development. In other words,
 we should stop asking — how much longer will it take? Are we on track?
 Can we complete today? And instead ask, is it shipped?
 
-My last crib about standup’s is that it is disruptive to my schedule.
+My last crib about standups is that it is disruptive to my schedule.
 Paul Graham has an [excellent article on this](http://www.paulgraham.com/makersschedule.html).
-While this form (standup’s) of updates are great for managers/management,
+While this form (standups) of updates are great for managers/management,
 there is no time of the day when such a meeting will not disrupt the ‘makers’.
 
 So I find it strange that we start with the principle of self-organizing
-teams and then conclude — standup’s at 9! How does open-source work if
-standup’s are how development should be done?
+teams and then conclude — standups at 9! How does open-source work if
+standups are how development should be done?
 
 These are my thoughts as an individual, of course.

--- a/_posts/weapons-of-choice.mdx
+++ b/_posts/weapons-of-choice.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Weapons of choice'
+seoTitle: 'Lessons from building a Node.js app on Heroku and MongoDB'
 excerpt: 'Last month, I worked on a Nodejs project in my freetime. It is a community driven listing of events in a city. The idea was to answer the question — what is happening in city X? I have a few takeaways from that exercise that I think maybe interesting.'
 coverImage:
   src: 'https://user-images.githubusercontent.com/222507/109567726-1ba81880-7ae6-11eb-962c-f52c9a4b69fa.png'

--- a/pages/posts/[slug].tsx
+++ b/pages/posts/[slug].tsx
@@ -60,6 +60,7 @@ const Post: React.FC<PostProps> = ({ post, source }) => {
       name: AUTHOR_NAME,
       url: `${SITE_URL}/about`,
     },
+    ...(post.seoTitle && { alternativeHeadline: post.seoTitle }),
     ...(tags.length > 0 && { keywords: tags.join(', ') }),
   }
 
@@ -67,7 +68,7 @@ const Post: React.FC<PostProps> = ({ post, source }) => {
     <Layout description={post.excerpt} image={post.ogImage.url}>
       <JsonLd data={blogPosting} />
       <Head>
-        <title>{post.title + ' | Blog of ' + AUTHOR_NAME}</title>
+        <title>{post.seoTitle ?? post.title}</title>
         <meta property="og:type" content="article" key="ogType" />
         <meta property="og:title" content={post.title} key="ogTitle" />
         <meta
@@ -141,6 +142,7 @@ type Params = {
 export async function getStaticProps({ params }: Params) {
   const post = getPostBySlug(params.slug, [
     'title',
+    'seoTitle',
     'excerpt',
     'date',
     'slug',

--- a/types/post.ts
+++ b/types/post.ts
@@ -4,6 +4,7 @@ import { ImageProps } from '../components/cover-image'
 type PostType = {
   slug: string
   title: string
+  seoTitle?: string
   date: string
   coverImage: ImageProps
   author: Author


### PR DESCRIPTION
Posts take an optional seoTitle in frontmatter that feeds only the <title> tag, so the heading on the page keeps its voice while search results get a plain description. The site-name suffix is dropped from post titles. og:title, twitter:title and the JSON-LD headline stay on the display title, with seoTitle added as alternativeHeadline.

Also corrects two headings: 'Nodejs vs Django' becomes 'Node.js vs Django', and 'Standup's' becomes the plural 'standups' in the title, excerpt and body.