### PR TITLE
Link to caulagi.com from the header and footer

### DIFF
--- a/components/external-link.tsx
+++ b/components/external-link.tsx
@@ -1,10 +1,11 @@
 type ExternalLinkProps = {
   href: string
+  rel?: string
   children: React.ReactNode
 }
 
-const ExternalLink: React.FC<ExternalLinkProps> = ({ href, children }) => (
-  <a href={href} target="_blank" rel="noreferrer">
+const ExternalLink: React.FC<ExternalLinkProps> = ({ href, rel, children }) => (
+  <a href={href} target="_blank" rel={rel ? `${rel} noreferrer` : 'noreferrer'}>
     {children}
     <span className="external-arrow" aria-hidden="true">
       ↗

--- a/components/external-link.tsx
+++ b/components/external-link.tsx
@@ -1,0 +1,16 @@
+type ExternalLinkProps = {
+  href: string
+  children: React.ReactNode
+}
+
+const ExternalLink: React.FC<ExternalLinkProps> = ({ href, children }) => (
+  <a href={href} target="_blank" rel="noreferrer">
+    {children}
+    <span className="external-arrow" aria-hidden="true">
+      ↗
+    </span>
+    <span className="visually-hidden"> (opens in a new window)</span>
+  </a>
+)
+
+export default ExternalLink

--- a/components/site-footer.tsx
+++ b/components/site-footer.tsx
@@ -1,8 +1,10 @@
+import ExternalLink from './external-link'
 import {
   AUTHOR_NAME,
   GIT_REPO,
   LINKEDIN_URL,
   MASTODON_URL,
+  PERSONAL_SITE_URL,
 } from '../lib/constants'
 
 const SiteFooter: React.FC = () => {
@@ -12,6 +14,7 @@ const SiteFooter: React.FC = () => {
         © {new Date().getFullYear()} {AUTHOR_NAME}
       </span>
       <span>
+        <ExternalLink href={PERSONAL_SITE_URL}>caulagi.com</ExternalLink> ·{' '}
         <a href="/feed.xml">RSS</a> ·{' '}
         <a href={MASTODON_URL} rel="me noreferrer" target="_blank">
           Mastodon

--- a/components/site-footer.tsx
+++ b/components/site-footer.tsx
@@ -23,7 +23,7 @@ const SiteFooter: React.FC = () => {
         <ExternalLink href={LINKEDIN_URL} rel="me">
           LinkedIn
         </ExternalLink>{' '}
-        · <ExternalLink href={GIT_REPO}>Source</ExternalLink>
+        · <ExternalLink href={GIT_REPO}>GitHub</ExternalLink>
       </span>
     </footer>
   )

--- a/components/site-footer.tsx
+++ b/components/site-footer.tsx
@@ -16,17 +16,14 @@ const SiteFooter: React.FC = () => {
       <span>
         <ExternalLink href={PERSONAL_SITE_URL}>caulagi.com</ExternalLink> ·{' '}
         <a href="/feed.xml">RSS</a> ·{' '}
-        <a href={MASTODON_URL} rel="me noreferrer" target="_blank">
+        <ExternalLink href={MASTODON_URL} rel="me">
           Mastodon
-        </a>{' '}
+        </ExternalLink>{' '}
         ·{' '}
-        <a href={LINKEDIN_URL} rel="me noreferrer" target="_blank">
+        <ExternalLink href={LINKEDIN_URL} rel="me">
           LinkedIn
-        </a>{' '}
-        ·{' '}
-        <a href={GIT_REPO} target="_blank" rel="noreferrer">
-          Source
-        </a>
+        </ExternalLink>{' '}
+        · <ExternalLink href={GIT_REPO}>Source</ExternalLink>
       </span>
     </footer>
   )

--- a/components/site-header.tsx
+++ b/components/site-header.tsx
@@ -13,9 +13,7 @@ const SiteHeader: React.FC = () => {
         <nav className="site-nav">
           <ExternalLink href={PERSONAL_SITE_URL}>caulagi.com</ExternalLink>
           <Link href="/about">About</Link>
-          <a href={GIT_REPO} target="_blank" rel="noreferrer">
-            GitHub
-          </a>
+          <ExternalLink href={GIT_REPO}>GitHub</ExternalLink>
         </nav>
       </header>
       <div className="header-rule" />

--- a/components/site-header.tsx
+++ b/components/site-header.tsx
@@ -1,6 +1,7 @@
 import Link from 'next/link'
 
-import { GIT_REPO } from '../lib/constants'
+import ExternalLink from './external-link'
+import { GIT_REPO, PERSONAL_SITE_URL } from '../lib/constants'
 
 const SiteHeader: React.FC = () => {
   return (
@@ -10,7 +11,7 @@ const SiteHeader: React.FC = () => {
           Caulagi
         </Link>
         <nav className="site-nav">
-          <Link href="/">Posts</Link>
+          <ExternalLink href={PERSONAL_SITE_URL}>caulagi.com</ExternalLink>
           <Link href="/about">About</Link>
           <a href={GIT_REPO} target="_blank" rel="noreferrer">
             GitHub

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,7 +1,7 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
-import "./.next/types/root-params.d.ts";
+import "./.next/dev/types/routes.d.ts";
+import "./.next/dev/types/root-params.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/pages/api-reference/config/typescript for more information.

--- a/styles/index.css
+++ b/styles/index.css
@@ -72,6 +72,25 @@ img {
   max-width: 100%;
 }
 
+.external-arrow {
+  font-size: 0.85em;
+  line-height: 1;
+  margin-left: 3px;
+  vertical-align: baseline;
+}
+
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  overflow: hidden;
+  clip-path: inset(50%);
+  white-space: nowrap;
+  border: 0;
+}
+
 .shell {
   max-width: var(--measure);
   margin: 0 auto;


### PR DESCRIPTION
Replaces the Posts item in the header nav with a link to caulagi.com, and adds the same link to the footer. Both open in a new window and carry an up arrow to say so.