### PR TITLE
Update the README to describe the current stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,19 @@
 
 [![CI](https://github.com/caulagi/blog/actions/workflows/ci.yml/badge.svg)](https://github.com/caulagi/blog/actions/workflows/ci.yml)
 
-The blog uses next.js, mdx, typescript, and tailwindcss. The pages are statically generated at build time.
+The blog uses next.js, mdx and typescript. The pages are statically generated at build time.
 
-The blog posts are stored in `/_posts` as mdx files with front matter support. Adding a new Markdown file in there will create a new blog post.
+The blog posts are stored in `/_posts` as mdx files with front matter support. Adding a new mdx file in there will create a new blog post. The metadata of every post is handled by [`gray-matter`][gray-matter] and sent in props to the page.
 
-To create the blog posts we use [`remark`][remark] and [`remark-html`][remark-html] to convert the mdx files into an HTML string, and then send it down as a prop to the page. The metadata of every post is handled by [`gray-matter`][gray-matter] and also sent in props to the page.
+## Key choices
+
+**Plain CSS, no framework.** The whole design lives in [`styles/index.css`][styles] as custom properties and semantic class names — `.masthead`, `.post-row`, `.prose-blog`, `.code-card`. Nothing is generated from utility classes, so a change to the look is a change to one file. [Newsreader][newsreader] is the reading face and [JetBrains Mono][jetbrains-mono] carries metadata and code.
+
+**Posts render through [`next-mdx-remote`][next-mdx-remote].** `getStaticProps` serializes the mdx and the page hands it to `MDXRemote`, which is what lets a post mix markdown with components like `<PullQuote>` and `<Contact />`.
+
+**Code blocks are highlighted at build time** by [`rehype-pretty-code`][rehype-pretty-code] and [`shiki`][shiki]. The theme in `lib/code-theme.ts` is the site palette rather than an off-the-shelf one, and a small rehype plugin, `lib/rehype-code-card.ts`, rewrites shiki's output into the dark card. A fence's `title=` becomes the filename in the card header.
+
+**Feeds are routes, not files.** `/feed.xml` and `/sitemap.xml` are generated from the posts on request, so neither can drift out of date; only `robots.txt` is static.
 
 ## Getting started
 
@@ -14,6 +22,8 @@ To create the blog posts we use [`remark`][remark] and [`remark-html`][remark-ht
 $ npm install
 $ npm run dev
 ```
+
+`npm run typecheck` and `npm run lint` are what CI runs. Formatting is [`prettier`][prettier], enforced on commit.
 
 ### History
 
@@ -23,6 +33,11 @@ Git commit history doesn't accurately reflect the history of the articles prior 
 
 This project is licensed under [`MIT`](LICENSE).
 
-[remark]: https://github.com/remarkjs/remark
-[remark-html]: https://github.com/remarkjs/remark-html
 [gray-matter]: https://github.com/jonschlinkert/gray-matter
+[jetbrains-mono]: https://www.jetbrains.com/lp/mono/
+[newsreader]: https://fonts.google.com/specimen/Newsreader
+[next-mdx-remote]: https://github.com/hashicorp/next-mdx-remote
+[prettier]: https://prettier.io/
+[rehype-pretty-code]: https://rehype-pretty.pages.dev/
+[shiki]: https://shiki.style/
+[styles]: styles/index.css


### PR DESCRIPTION
The README described tailwindcss and a remark/remark-html pipeline, none of which the blog uses any more. Replaces that with the choices behind the current build: plain CSS, next-mdx-remote, build-time highlighting with a site-matched shiki theme, and generated feed and sitemap routes.